### PR TITLE
Update QuitRoutine.F90

### DIFF
--- a/src/FlowSolver/QuitRoutine.F90
+++ b/src/FlowSolver/QuitRoutine.F90
@@ -40,7 +40,7 @@ subroutine QuitRoutine(tin,normalexit,errorcode)
             call MPI_ABORT(MPI_COMM_WORLD,1)
         end if
 
-        call FinalizeParticleSolver
+        if (particle) call FinalizeParticleSolver
         call DeallocateVariables
         call DeallocateFFTArrays
         call HdfClose


### PR DESCRIPTION
Bugfix for cases where variable "particle" is false. Quit routine would throw a memory access error when trying to use MPI_TYPE_FREE in FinalizeParticleSolver when the MPI_TYPE for particle data "mpi_pdat" wasn't allocated.